### PR TITLE
feat: add events, constants, and mint/updateWeather functions to DynamicNFT

### DIFF
--- a/src/DynamicNFT.sol
+++ b/src/DynamicNFT.sol
@@ -82,4 +82,15 @@ contract DynamicNFT is ERC721, Ownable {
         emit NFTMinted(tokenId, to);
         return tokenId;
     }
+
+        function updateWeather(uint256 tokenId) external {
+        require(_ownerOf(tokenId) != address(0), "Token does not exist");
+        require(block.timestamp >= nftStates[tokenId].lastWeatherUpdate + UPDATE_INTERVAL, "Too early to update");
+
+        string memory newWeather = weatherOracle.getData();
+        nftStates[tokenId].currentWeather = newWeather;
+        nftStates[tokenId].lastWeatherUpdate = block.timestamp;
+
+        emit NFTUpdated(tokenId, "weather", newWeather);
+    }
 }

--- a/src/DynamicNFT.sol
+++ b/src/DynamicNFT.sol
@@ -37,6 +37,9 @@ contract DynamicNFT is ERC721, Ownable {
     mapping(uint256 => NFTState) public nftStates;
     mapping(address => uint256[]) public userTokens;
 
+    // Events
+        event NFTMinted(uint256 indexed tokenId, address indexed owner);
+
     constructor(address _weatherOracle, address _timeOracle, address _metadataRenderer)
         ERC721("Dynamic Weather NFT", "DYNFT")
         Ownable(msg.sender)

--- a/src/DynamicNFT.sol
+++ b/src/DynamicNFT.sol
@@ -55,4 +55,28 @@ contract DynamicNFT is ERC721, Ownable {
         timeOracle = IDataOracle(_timeOracle);
         metadataRenderer = IMetadataRenderer(_metadataRenderer);
     }
+
+    function mint(address to) public onlyOwner returns (uint256) {
+        require(_tokenIdCounter < MAX_SUPPLY, "Max supply reached");
+        uint256 tokenId = _tokenIdCounter;
+        _tokenIdCounter++;
+
+        _safeMint(to, tokenId);
+
+        // Initialize NFT state
+        nftStates[tokenId] = NFTState({
+            lastWeatherUpdate: block.timestamp,
+            lastTimeUpdate: block.timestamp,
+            userActionCount: 0,
+            currentWeather: "sunny",
+            currentTimeOfDay: _getCurrentTimeOfDay(),
+            owner: to,
+            createdAt: block.timestamp
+        });
+
+        userTokens[to].push(tokenId);
+
+        emit NFTMinted(tokenId, to);
+        return tokenId;
+    }
 }

--- a/src/DynamicNFT.sol
+++ b/src/DynamicNFT.sol
@@ -38,14 +38,14 @@ contract DynamicNFT is ERC721, Ownable {
     mapping(address => uint256[]) public userTokens;
 
     // Events
-        event NFTMinted(uint256 indexed tokenId, address indexed owner);
+    event NFTMinted(uint256 indexed tokenId, address indexed owner);
     event NFTUpdated(uint256 indexed tokenId, string updateType, string newValue);
     event OracleUpdated(address indexed oracle, string oracleType);
     event UserAction(uint256 indexed tokenId, address indexed user, string action);
 
     // Constants
     uint256 public constant UPDATE_INTERVAL = 1 hours;
-        uint256 public constant MAX_SUPPLY = 10000;
+    uint256 public constant MAX_SUPPLY = 10000;
 
     constructor(address _weatherOracle, address _timeOracle, address _metadataRenderer)
         ERC721("Dynamic Weather NFT", "DYNFT")
@@ -86,7 +86,7 @@ contract DynamicNFT is ERC721, Ownable {
     /**
      * @dev Update NFT based on weather data
      */
-        function updateWeather(uint256 tokenId) external {
+    function updateWeather(uint256 tokenId) external {
         require(_ownerOf(tokenId) != address(0), "Token does not exist");
         require(block.timestamp >= nftStates[tokenId].lastWeatherUpdate + UPDATE_INTERVAL, "Too early to update");
 

--- a/src/DynamicNFT.sol
+++ b/src/DynamicNFT.sol
@@ -83,6 +83,9 @@ contract DynamicNFT is ERC721, Ownable {
         return tokenId;
     }
 
+    /**
+     * @dev Update NFT based on weather data
+     */
         function updateWeather(uint256 tokenId) external {
         require(_ownerOf(tokenId) != address(0), "Token does not exist");
         require(block.timestamp >= nftStates[tokenId].lastWeatherUpdate + UPDATE_INTERVAL, "Too early to update");

--- a/src/DynamicNFT.sol
+++ b/src/DynamicNFT.sol
@@ -40,6 +40,7 @@ contract DynamicNFT is ERC721, Ownable {
     // Events
         event NFTMinted(uint256 indexed tokenId, address indexed owner);
     event NFTUpdated(uint256 indexed tokenId, string updateType, string newValue);
+    event OracleUpdated(address indexed oracle, string oracleType);
 
     constructor(address _weatherOracle, address _timeOracle, address _metadataRenderer)
         ERC721("Dynamic Weather NFT", "DYNFT")

--- a/src/DynamicNFT.sol
+++ b/src/DynamicNFT.sol
@@ -45,7 +45,8 @@ contract DynamicNFT is ERC721, Ownable {
 
     // Constants
     uint256 public constant UPDATE_INTERVAL = 1 hours;
-    
+        uint256 public constant MAX_SUPPLY = 10000;
+
     constructor(address _weatherOracle, address _timeOracle, address _metadataRenderer)
         ERC721("Dynamic Weather NFT", "DYNFT")
         Ownable(msg.sender)

--- a/src/DynamicNFT.sol
+++ b/src/DynamicNFT.sol
@@ -56,6 +56,9 @@ contract DynamicNFT is ERC721, Ownable {
         metadataRenderer = IMetadataRenderer(_metadataRenderer);
     }
 
+    /**
+     * @dev Mint a new dynamic NFT
+     */
     function mint(address to) public onlyOwner returns (uint256) {
         require(_tokenIdCounter < MAX_SUPPLY, "Max supply reached");
         uint256 tokenId = _tokenIdCounter;

--- a/src/DynamicNFT.sol
+++ b/src/DynamicNFT.sol
@@ -41,7 +41,11 @@ contract DynamicNFT is ERC721, Ownable {
         event NFTMinted(uint256 indexed tokenId, address indexed owner);
     event NFTUpdated(uint256 indexed tokenId, string updateType, string newValue);
     event OracleUpdated(address indexed oracle, string oracleType);
+    event UserAction(uint256 indexed tokenId, address indexed user, string action);
 
+    // Constants
+    uint256 public constant UPDATE_INTERVAL = 1 hours;
+    
     constructor(address _weatherOracle, address _timeOracle, address _metadataRenderer)
         ERC721("Dynamic Weather NFT", "DYNFT")
         Ownable(msg.sender)

--- a/src/DynamicNFT.sol
+++ b/src/DynamicNFT.sol
@@ -39,6 +39,7 @@ contract DynamicNFT is ERC721, Ownable {
 
     // Events
         event NFTMinted(uint256 indexed tokenId, address indexed owner);
+    event NFTUpdated(uint256 indexed tokenId, string updateType, string newValue);
 
     constructor(address _weatherOracle, address _timeOracle, address _metadataRenderer)
         ERC721("Dynamic Weather NFT", "DYNFT")


### PR DESCRIPTION
# PR Description
## Summary
This PR enhances the `DynamicNFT` contract by introducing **events**, **constants**, and two new **core external functions** for minting and weather-based updates.

## What's Changed
- 📢 **Events**
  - `NFTMinted` → emitted when a new NFT is minted.
  - `NFTUpdated` → emitted when NFT attributes are updated.
  - `OracleUpdated` → emitted when oracle sources change.
  - `UserAction` → emitted when users interact with their NFTs.

- 🔢 **Constants**
  - `UPDATE_INTERVAL = 1 hours` → minimum interval between weather updates.
  - `MAX_SUPPLY = 10000` → cap on total NFTs.

- ⚙️ **Functions**
  - `mint(address to)` (onlyOwner):
    - Mints a new NFT, assigns initial state, and enforces `MAX_SUPPLY`.
    - Stores metadata in `nftStates` and updates `userTokens`.
    - Emits `NFTMinted`.
  - `updateWeather(uint256 tokenId)` (external):
    - Fetches new weather data from the oracle.
    - Updates the NFT’s weather state if enough time has passed (`UPDATE_INTERVAL`).
    - Emits `NFTUpdated`.

- 📝 Added **NatSpec comments** for clarity and documentation.
- 🎨 Applied `forge fmt` for consistent code formatting.

## Why
- Provides **minting logic** with supply control.
- Introduces **dynamic weather updates**, making NFTs reactive to real-world data.
- Adds **event tracking** for better transparency and monitoring in dApps.
- Improves maintainability with constants for critical parameters.

## Impact
- ✅ Admins can now mint NFTs up to the capped supply.
- ✅ NFTs evolve dynamically with weather data, increasing utility and engagement.
- 🔒 Ensures updates are time-gated to prevent spam or manipulation.
- 🛠 Facilitates external integrations by emitting rich events.

## Notes
- Future work may include extending `updateWeather` to also refresh **time-of-day** or other oracle-based attributes.
