### PR TITLE
feat: add time-of-day updates and user action tracking to DynamicNFT

### DIFF
--- a/src/DynamicNFT.sol
+++ b/src/DynamicNFT.sol
@@ -96,4 +96,15 @@ contract DynamicNFT is ERC721, Ownable {
 
         emit NFTUpdated(tokenId, "weather", newWeather);
     }
+
+        function updateTimeOfDay(uint256 tokenId) external {
+        require(_ownerOf(tokenId) != address(0), "Token does not exist");
+        require(block.timestamp >= nftStates[tokenId].lastTimeUpdate + UPDATE_INTERVAL, "Too early to update");
+
+        string memory newTimeOfDay = _getCurrentTimeOfDay();
+        nftStates[tokenId].currentTimeOfDay = newTimeOfDay;
+        nftStates[tokenId].lastTimeUpdate = block.timestamp;
+
+        emit NFTUpdated(tokenId, "timeOfDay", newTimeOfDay);
+    }
 }

--- a/src/DynamicNFT.sol
+++ b/src/DynamicNFT.sol
@@ -97,6 +97,9 @@ contract DynamicNFT is ERC721, Ownable {
         emit NFTUpdated(tokenId, "weather", newWeather);
     }
 
+    /**
+     * @dev Update NFT based on time of day
+     */
         function updateTimeOfDay(uint256 tokenId) external {
         require(_ownerOf(tokenId) != address(0), "Token does not exist");
         require(block.timestamp >= nftStates[tokenId].lastTimeUpdate + UPDATE_INTERVAL, "Too early to update");

--- a/src/DynamicNFT.sol
+++ b/src/DynamicNFT.sol
@@ -123,4 +123,13 @@ contract DynamicNFT is ERC721, Ownable {
         emit UserAction(tokenId, msg.sender, action);
         emit NFTUpdated(tokenId, "userAction", Strings.toString(nftStates[tokenId].userActionCount));
     }
+
+    function _getCurrentTimeOfDay() internal view returns (string memory) {
+        uint256 hour = (block.timestamp / 3600) % 24;
+
+        if (hour >= 6 && hour < 12) return "morning";
+        if (hour >= 12 && hour < 18) return "afternoon";
+        if (hour >= 18 && hour < 22) return "evening";
+        return "night";
+    }
 }

--- a/src/DynamicNFT.sol
+++ b/src/DynamicNFT.sol
@@ -124,6 +124,9 @@ contract DynamicNFT is ERC721, Ownable {
         emit NFTUpdated(tokenId, "userAction", Strings.toString(nftStates[tokenId].userActionCount));
     }
 
+    /**
+     * @dev Get current time of day based on block timestamp
+     */
     function _getCurrentTimeOfDay() internal view returns (string memory) {
         uint256 hour = (block.timestamp / 3600) % 24;
 

--- a/src/DynamicNFT.sol
+++ b/src/DynamicNFT.sol
@@ -100,7 +100,7 @@ contract DynamicNFT is ERC721, Ownable {
     /**
      * @dev Update NFT based on time of day
      */
-        function updateTimeOfDay(uint256 tokenId) external {
+    function updateTimeOfDay(uint256 tokenId) external {
         require(_ownerOf(tokenId) != address(0), "Token does not exist");
         require(block.timestamp >= nftStates[tokenId].lastTimeUpdate + UPDATE_INTERVAL, "Too early to update");
 
@@ -114,7 +114,7 @@ contract DynamicNFT is ERC721, Ownable {
     /**
      * @dev Record user action that affects NFT
      */
-        function performUserAction(uint256 tokenId, string calldata action) external {
+    function performUserAction(uint256 tokenId, string calldata action) external {
         require(_ownerOf(tokenId) != address(0), "Token does not exist");
         require(ownerOf(tokenId) == msg.sender, "Not token owner");
 

--- a/src/DynamicNFT.sol
+++ b/src/DynamicNFT.sol
@@ -110,4 +110,14 @@ contract DynamicNFT is ERC721, Ownable {
 
         emit NFTUpdated(tokenId, "timeOfDay", newTimeOfDay);
     }
+
+        function performUserAction(uint256 tokenId, string calldata action) external {
+        require(_ownerOf(tokenId) != address(0), "Token does not exist");
+        require(ownerOf(tokenId) == msg.sender, "Not token owner");
+
+        nftStates[tokenId].userActionCount++;
+
+        emit UserAction(tokenId, msg.sender, action);
+        emit NFTUpdated(tokenId, "userAction", Strings.toString(nftStates[tokenId].userActionCount));
+    }
 }

--- a/src/DynamicNFT.sol
+++ b/src/DynamicNFT.sol
@@ -111,6 +111,9 @@ contract DynamicNFT is ERC721, Ownable {
         emit NFTUpdated(tokenId, "timeOfDay", newTimeOfDay);
     }
 
+    /**
+     * @dev Record user action that affects NFT
+     */
         function performUserAction(uint256 tokenId, string calldata action) external {
         require(_ownerOf(tokenId) != address(0), "Token does not exist");
         require(ownerOf(tokenId) == msg.sender, "Not token owner");


### PR DESCRIPTION
# PR Description
## Summary
This PR extends **DynamicNFT** with new functions that make NFTs more dynamic and interactive by incorporating **time-of-day state changes** and **user-driven actions**.

## What's Changed
- ➕ **updateTimeOfDay**
  - External function to update an NFT’s state based on the current time of day.
  - Enforces update interval checks to prevent spamming.
  - Emits `NFTUpdated` event when state changes.

- ➕ **performUserAction**
  - External function that allows NFT owners to record actions affecting their NFT.
  - Increments `userActionCount` for the token.
  - Emits both `UserAction` and `NFTUpdated` events.

- ➕ **_getCurrentTimeOfDay**
  - Internal helper function that determines the current time segment (`morning`, `afternoon`, `evening`, `night`) from block timestamp.
  - Used by `updateTimeOfDay`.

- 🧹 **Formatting**
  - Applied `forge fmt` for consistent code style.

## Why
- Introduces **real-world temporal dynamics** (NFTs evolve with time of day).  
- Allows **user interaction** to directly impact NFT state, making NFTs more personalized and engaging.  
- Expands use cases for dynamic metadata and on-chain gamification.  

## Impact
- ✅ NFTs now change appearance/state based on time-of-day updates.  
- ✅ Owners can interact with their NFTs via `performUserAction`.  
- ✅ Event logs (`NFTUpdated`, `UserAction`) provide a clear audit trail of changes.  

## Next Steps
- Integrate time-of-day metadata updates with the **renderer**.  
- Add support for **batch updates** (multiple tokens at once).  
- Explore **action-based achievements** or leveling system for NFTs.  
