### PR TITLE
feat: add dynamic tokenURI override and NFT view functions

### DIFF
--- a/src/DynamicNFT.sol
+++ b/src/DynamicNFT.sol
@@ -160,4 +160,9 @@ contract DynamicNFT is ERC721, Ownable {
     function getTokensOfOwner(address owner) external view returns (uint256[] memory) {
         return userTokens[owner];
     }
+
+    function getNFTState(uint256 tokenId) external view returns (NFTState memory) {
+        require(_ownerOf(tokenId) != address(0), "Token does not exist");
+        return nftStates[tokenId];
+    }
 }

--- a/src/DynamicNFT.sol
+++ b/src/DynamicNFT.sol
@@ -139,7 +139,7 @@ contract DynamicNFT is ERC721, Ownable {
     /**
      * @dev Override tokenURI to return dynamic metadata
      */
-        function tokenURI(uint256 tokenId) public view override returns (string memory) {
+    function tokenURI(uint256 tokenId) public view override returns (string memory) {
         require(_ownerOf(tokenId) != address(0), "Token does not exist");
         NFTState memory state = nftStates[tokenId];
         IMetadataRenderer.NFTState memory rendererState = IMetadataRenderer.NFTState({

--- a/src/DynamicNFT.sol
+++ b/src/DynamicNFT.sol
@@ -136,6 +136,9 @@ contract DynamicNFT is ERC721, Ownable {
         return "night";
     }
 
+    /**
+     * @dev Override tokenURI to return dynamic metadata
+     */
         function tokenURI(uint256 tokenId) public view override returns (string memory) {
         require(_ownerOf(tokenId) != address(0), "Token does not exist");
         NFTState memory state = nftStates[tokenId];

--- a/src/DynamicNFT.sol
+++ b/src/DynamicNFT.sol
@@ -161,6 +161,9 @@ contract DynamicNFT is ERC721, Ownable {
         return userTokens[owner];
     }
 
+    /**
+     * @dev Get NFT state for a token
+     */
     function getNFTState(uint256 tokenId) external view returns (NFTState memory) {
         require(_ownerOf(tokenId) != address(0), "Token does not exist");
         return nftStates[tokenId];

--- a/src/DynamicNFT.sol
+++ b/src/DynamicNFT.sol
@@ -135,4 +135,19 @@ contract DynamicNFT is ERC721, Ownable {
         if (hour >= 18 && hour < 22) return "evening";
         return "night";
     }
+
+        function tokenURI(uint256 tokenId) public view override returns (string memory) {
+        require(_ownerOf(tokenId) != address(0), "Token does not exist");
+        NFTState memory state = nftStates[tokenId];
+        IMetadataRenderer.NFTState memory rendererState = IMetadataRenderer.NFTState({
+            lastWeatherUpdate: state.lastWeatherUpdate,
+            lastTimeUpdate: state.lastTimeUpdate,
+            userActionCount: state.userActionCount,
+            currentWeather: state.currentWeather,
+            currentTimeOfDay: state.currentTimeOfDay,
+            owner: state.owner,
+            createdAt: state.createdAt
+        });
+        return metadataRenderer.renderMetadata(tokenId, rendererState);
+    }
 }

--- a/src/DynamicNFT.sol
+++ b/src/DynamicNFT.sol
@@ -154,6 +154,9 @@ contract DynamicNFT is ERC721, Ownable {
         return metadataRenderer.renderMetadata(tokenId, rendererState);
     }
 
+    /**
+     * @dev Get all tokens owned by an address
+     */
     function getTokensOfOwner(address owner) external view returns (uint256[] memory) {
         return userTokens[owner];
     }

--- a/src/DynamicNFT.sol
+++ b/src/DynamicNFT.sol
@@ -153,4 +153,8 @@ contract DynamicNFT is ERC721, Ownable {
         });
         return metadataRenderer.renderMetadata(tokenId, rendererState);
     }
+
+    function getTokensOfOwner(address owner) external view returns (uint256[] memory) {
+        return userTokens[owner];
+    }
 }


### PR DESCRIPTION
# PR Description
## Summary
This PR enhances **DynamicNFT** by introducing a `tokenURI` override for dynamic metadata rendering and new view functions that improve transparency and accessibility of NFT data.

## What's Changed
- ➕ **tokenURI (override)**
  - Public view function returning metadata via `metadataRenderer.renderMetadata`.
  - Integrates dynamic state (`weather`, `timeOfDay`, `userActionCount`, etc.) into metadata.
  - Ensures token existence before returning metadata.

- ➕ **getTokensOfOwner**
  - External view function that retrieves all token IDs owned by a given address.
  - Returns `userTokens[owner]`.

- ➕ **getNFTState**
  - External view function to return the full `NFTState` struct for a specific token.
  - Provides direct access to dynamic state without parsing events.

- 🧹 **Formatting**
  - Applied `forge fmt` for consistent style.

## Why
- Makes NFTs **dynamic at the metadata level**, ensuring marketplaces like OpenSea and explorers always reflect the latest state.  
- Provides developers and users with **easier ways to query ownership and NFT state**.  
- Improves integration with off-chain apps and dashboards without requiring custom indexing.  

## Impact
- ✅ Marketplaces fetch up-to-date metadata through `tokenURI`.  
- ✅ Users can directly query their tokens and associated states.  
- ✅ Cleaner developer experience with dedicated view functions.  

## Next Steps
- Extend `tokenURI` to support **batch metadata queries**.  
- Add pagination support for `getTokensOfOwner` if owner has many NFTs.  
- Explore caching layers for heavy metadata rendering.  
